### PR TITLE
Add cache to mitigate the iteration between fleet and systemd-dbus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	UnitStateTTL            string
 	VerifyUnits             bool
 	AuthorizedKeysFile      string
+	EnableUnitStateCache    bool
 }
 
 func (c *Config) Metadata() map[string]string {

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -82,6 +82,7 @@ func main() {
 	cfgset.String("unit_state_ttl", agent.DefaultUnitStateTTL, "TTL in seconds of unit state in etcd")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")
+	cfgset.Bool("enable_unitstate_cache", true, "Enable an unit state cache to minimize the systemd and dbus communication overhead.")
 
 	globalconf.Register("", cfgset)
 	cfg, err := getConfig(cfgset, *cfgPath)
@@ -210,8 +211,12 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		UnitStateTTL:            (*flagset.Lookup("unit_state_ttl")).Value.(flag.Getter).Get().(string),
 		VerifyUnits:             (*flagset.Lookup("verify_units")).Value.(flag.Getter).Get().(bool),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
+		EnableUnitStateCache:    (*flagset.Lookup("enable_unitstate_cache")).Value.(flag.Getter).Get().(bool),
 	}
 
+	if cfg.EnableUnitStateCache {
+		log.Info("Config option enable_unitstate_cache is activated")
+	}
 	if cfg.VerifyUnits {
 		log.Error("Config option verify_units is no longer supported - ignoring")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -67,7 +67,7 @@ func New(cfg config.Config) (*Server, error) {
 		return nil, err
 	}
 
-	mgr, err := systemd.NewSystemdUnitManager(systemd.DefaultUnitsDirectory)
+	mgr, err := systemd.NewSystemdUnitManager(cfg, systemd.DefaultUnitsDirectory)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Dbus cache: 

**Motivation:** Inactive units induce an overload to systemd-dbus communication which linearly increases proportionally to the amount of existing inactive units. Therefore, we decided to research about solutions to minimize the workload of fleet caused by this issue. We decided to build a cache to reduce the amount of calls from systemd to dbus. Fleet periodically perform operation to gather the state of the units in the cluster, so for each inactive unit located in a host an read operation is triggered to obtain the state from dbus. 

Nevertheless, we thought about another optimal solution during the development of this cache. This solution requires to modify the `go-dbus` library implementation to provide an event-driven mechanism. This event-driven mechanism would notify every time an operation affects the state of a unit. This notifications would allows to know when the state of a unit change without having to constantly query systemd to get the state.  Obviously we declined this solution as it required the modification of third party software used by fleet.
## Implementation

We added a new flag `enable_unitstate_cache` that will activate the usage of the unit state cache and therefore to minimize the usage of the system resources.
### Scenario:
- 3 node cluster
- gs2 fleet version
- CoreOS stable (835.9.0)
## Metrics analyzed:
- CPU usage
- Memory usage
- FS bytes usage
- NET bytes IN
- NET bytes OUT
- NET bytes TOTAL 
- Capacity used
### Savings deducted from the experiments:

A brief and quick summary:
- There is a clear CPU reduction using the DBUS cache. It can be seen as approx. 10% CPU usage reduction. However this amount will increase based on the number of inactive units.
- There is a clear Memory usage reduction using the DBUS cache. Approx. 100Mb Memory usage reduction. However this amount will increase based on the number of inactive units.
- FS bytes used during the experiments slightly INCREASED with the DBUS implementation
- NET bytes IN/OUT used during the experiments slightly INCREASED in the implementation WITHOUT cache.
- Capacity used obviously dropped when using the DBUS cache
### Experiment 1:

Without any iteration in the cluster, we evaluate how affects to have 3 inactive units in a host.
#### CPU usage of DBUS cache:

<img width="1139" alt="screen shot 2016-01-21 at 6 06 52 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488013/e27eac54-c069-11e5-8270-90e8e0268def.png">
#### Memory usage of DBUS cache:

<img width="1133" alt="screen shot 2016-01-21 at 6 07 11 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488014/e2848f2a-c069-11e5-8f3f-4335946689c5.png">
#### CPU usage WITHOUT cache:

<img width="1134" alt="screen shot 2016-01-21 at 6 04 31 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488084/28bcae3c-c06a-11e5-9bcc-5f106455dfe6.png">
#### Memory usage WITHOUT cache:

<img width="1139" alt="screen shot 2016-01-21 at 6 04 59 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488085/28bdcd6c-c06a-11e5-92c2-26b49f5fd1fa.png">
### Experiment 2:

We used a benchmarking tool that starts 900 units in the cluster, stop and consequently after a timeout destroy them.
#### CPU usage of DBUS cache:

<img width="1127" alt="screen shot 2016-01-21 at 5 39 26 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487096/00660e50-c066-11e5-8e5d-477e1a3587b2.png">
#### CPU usage WITHOUT cache:
## <img width="1130" alt="screen shot 2016-01-21 at 6 15 52 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488263/0df22ad6-c06b-11e5-9982-4b4ad56675cb.png">
### Memory usage of DBUS cache:

<img width="1077" alt="screen shot 2016-01-21 at 3 59 26 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487117/199194c6-c066-11e5-8c26-81850174d56e.png">
### Memory usage WITHOUT cache:
## <img width="1132" alt="screen shot 2016-01-21 at 6 15 38 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488262/0de70872-c06b-11e5-8986-cdcbc7f12350.png">
### FS bytes used of DBUS cache:

<img width="875" alt="screen shot 2016-01-21 at 3 59 37 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487119/19951f88-c066-11e5-956c-898712b940ab.png">
### FS bytes used WITHOUT cache:
## <img width="876" alt="screen shot 2016-01-21 at 3 57 13 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488707/3e9df2f8-c06d-11e5-9673-7b6d558371b6.png">
### Capacity usage of DBUS cache:

<img width="878" alt="screen shot 2016-01-21 at 3 59 44 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487118/1993d8a8-c066-11e5-9fd4-2952173705de.png">
### Capacity used WITHOUT cache:
## <img width="875" alt="screen shot 2016-01-21 at 3 57 21 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488709/3ea51d26-c06d-11e5-81d2-3b8435e7ac8f.png">
### Net bytes IN of DBUS cache:

<img width="878" alt="screen shot 2016-01-21 at 3 59 54 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487116/1990d072-c066-11e5-993c-f06b3b95d7d0.png">
### Net bytes IN WITHOUT cache:
## <img width="881" alt="screen shot 2016-01-21 at 3 56 42 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488706/3e9c0ee8-c06d-11e5-8f6e-138ff6a37809.png">
### Net bytes OUT of DBUS cache:

<img width="873" alt="screen shot 2016-01-21 at 4 00 01 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487121/19aae1a6-c066-11e5-9927-98af0d682a23.png">
### Net bytes OUT WITHOUT cache:

<img width="871" alt="screen shot 2016-01-21 at 3 56 50 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488708/3ea1047a-c06d-11e5-9df1-69a46a78d27a.png">

---
### Net bytes total of DBUS cache:

<img width="886" alt="screen shot 2016-01-21 at 4 00 10 pm" src="https://cloud.githubusercontent.com/assets/3602792/12487120/19a9d4f0-c066-11e5-9c84-77ab220e1c27.png">
### Net bytes total WITHOUT cache:

<img width="1138" alt="screen shot 2016-01-21 at 6 38 58 pm" src="https://cloud.githubusercontent.com/assets/3602792/12488966/55b57cd0-c06e-11e5-959e-cf59a4ec509a.png">
## Related issues:

https://github.com/giantswarm/giantswarm/issues/288
https://github.com/giantswarm/giantswarm/issues/368
