### PR TITLE
[WIP] Scheduler weight agent state

### DIFF
--- a/build
+++ b/build
@@ -14,6 +14,8 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 eval $(go env)
+GOPATH=${GOPATH} go get github.com/pquerna/ffjson/ffjson
+GOPATH=${GOPATH} go get github.com/shirou/gopsutil
 
 if [ ${GOOS} = "linux" ]; then
 	echo "Building fleetd..."


### PR DESCRIPTION
I played a bit with the fleet scheduler is super easy to add a plugin to make more intelligent the scheduling part of fleet.

This algo simply makes use of CPU load, Mem usage, Num Units and Docker containers to give a weight to each fleet agent prior to take any scheduling decision.

ping @htr @giantswarm/team-core 
