### PR TITLE
Improvements saving the unit states in the cluster

### DIFF
--- a/agent/unit_state.go
+++ b/agent/unit_state.go
@@ -26,9 +26,10 @@ import (
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/unit"
+	pb "github.com/coreos/fleet/protobuf"
+
 )
 
-const numPublishers = 5
 
 func NewUnitStatePublisher(reg registry.Registry, mach machine.Machine, ttl time.Duration) *UnitStatePublisher {
 	return &UnitStatePublisher{
@@ -37,14 +38,12 @@ func NewUnitStatePublisher(reg registry.Registry, mach machine.Machine, ttl time
 		publisher:       newPublisher(reg, ttl),
 		cache:           make(map[string]*unit.UnitState),
 		cacheMutex:      sync.RWMutex{},
-		toPublish:       make(chan string),
-		toPublishStates: make(map[string]*unit.UnitState),
-		toPublishMutex:  sync.RWMutex{},
+		toPublish:       make(chan map[string]*unit.UnitState),
 		clock:           clockwork.NewRealClock(),
 	}
 }
 
-type publishFunc func(name string, us *unit.UnitState)
+type publishFunc func(unitStates map[string]*unit.UnitState)
 
 type UnitStatePublisher struct {
 	mach machine.Machine
@@ -56,11 +55,7 @@ type UnitStatePublisher struct {
 	// toPublish is a queue indicating unit names for which a state publish event should occur.
 	// It is possible for a unit name to end up in the queue for which a
 	// state has already been published, in which case it triggers a no-op.
-	toPublish chan string
-	// toPublishStates is a mapping containing the latest UnitState which
-	// should be published for each UnitName.
-	toPublishStates map[string]*unit.UnitState
-	toPublishMutex  sync.RWMutex
+	toPublish chan map[string]*unit.UnitState
 
 	publisher publishFunc
 
@@ -70,7 +65,7 @@ type UnitStatePublisher struct {
 // Run caches all of the heartbeat objects from the provided channel, publishing
 // them to the Registry every 5s. Heartbeat objects are also published as they
 // are received on the channel.
-func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeat, stop chan bool) {
+func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeats, stop chan bool) {
 	var period time.Duration
 	if p.ttl > 10*time.Second {
 		period = p.ttl * 4 / 5
@@ -84,56 +79,49 @@ func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeat, stop 
 			case <-stop:
 				return
 			case <-p.clock.After(period):
-				p.cacheMutex.Lock()
-				for name, us := range p.cache {
-					go p.queueForPublish(name, us)
+				if len(p.cache) > 0 {
+					go p.publisher(p.cache)
+
+					go func() {
+						p.cacheMutex.Lock()
+						for name, state := range p.cache {
+							if state == nil {
+								log.Infof("Cleaning content of cache for unit %s", name)
+								delete(p.cache, name)
+							}
+						}
+						p.cacheMutex.Unlock()
+					}()
 				}
-				p.pruneCache()
-				p.cacheMutex.Unlock()
+			case units := <-p.toPublish:
+					if len(units) > 0 {
+						go p.publisher(units)
+						p.clock.Now()
+					}
 			}
 		}
 	}()
 
 	machID := p.mach.State().ID
 
-	// Spawn goroutines to publish unit states. Each goroutine waits until
-	// it sees an event arrive on toPublish, then attempts to grab the
-	// relevant UnitState and publish it to the registry.
-	for i := 0; i < numPublishers; i++ {
-		go func() {
-			for {
-				select {
-				case <-stop:
-					return
-				case name := <-p.toPublish:
-					p.toPublishMutex.Lock()
-					// Grab the latest state by that name
-					us, ok := p.toPublishStates[name]
-					if !ok {
-						// If one doesn't exist, ignore.
-						p.toPublishMutex.Unlock()
-						continue
-					}
-					delete(p.toPublishStates, name)
-					p.toPublishMutex.Unlock()
-					p.publisher(name, us)
-
-				}
-			}
-		}()
-	}
-
 	for {
 		select {
 		case <-stop:
 			return
-		case bt := <-beatchan:
-			if bt.State != nil {
-				bt.State.MachineID = machID
+		case hearbeat := <-beatchan:
+			publishCache := false
+			for _, bt := range hearbeat.States {
+				if bt.State != nil {
+					bt.State.MachineID = machID
+				}
+
+				if p.updateCache(bt) {
+					publishCache = true
+				}
 			}
 
-			if p.updateCache(bt) {
-				go p.queueForPublish(bt.Name, bt.State)
+			if publishCache {
+				p.toPublish <- p.cache
 			}
 		}
 	}
@@ -143,10 +131,8 @@ func (p *UnitStatePublisher) MarshalJSON() ([]byte, error) {
 	p.cacheMutex.Lock()
 	data := struct {
 		Cache     map[string]*unit.UnitState
-		ToPublish map[string]*unit.UnitState
 	}{
 		Cache:     p.cache,
-		ToPublish: p.toPublishStates,
 	}
 	p.cacheMutex.Unlock()
 
@@ -159,19 +145,6 @@ func (p *UnitStatePublisher) pruneCache() {
 			delete(p.cache, name)
 		}
 	}
-}
-
-// queueForPublish notifies the publishing goroutines that a particular
-// UnitState should be published to the Registry. This can block and should be
-// called in a goroutine.
-func (p *UnitStatePublisher) queueForPublish(name string, us *unit.UnitState) {
-	p.toPublishMutex.Lock()
-	p.toPublishStates[name] = us
-	p.toPublishMutex.Unlock()
-	// This may block for some time, but even if it occurs after
-	// the above UnitState has already been published, it will
-	// simply trigger a no-op
-	p.toPublish <- name
 }
 
 // updateCache updates the cache of UnitStates which the UnitStatePublisher
@@ -196,35 +169,48 @@ func (p *UnitStatePublisher) updateCache(update *unit.UnitStateHeartbeat) (chang
 // UnitStatePublisher's cache are removed from the registry.
 func (p *UnitStatePublisher) Purge() {
 	for name := range p.cache {
-		p.publisher(name, nil)
+		p.cache[name] = nil
 	}
+	p.publisher(p.cache)
 }
 
 // newPublisher returns a publishFunc that publishes a single UnitState
 // by the given name to the provided Registry, with the given TTL
 func newPublisher(reg registry.Registry, ttl time.Duration) publishFunc {
-	return func(name string, us *unit.UnitState) {
-		if us == nil {
-			log.Debugf("Destroying UnitState(%s) in Registry", name)
-			err := reg.RemoveUnitState(name)
-			if err != nil {
-				log.Errorf("Failed to destroy UnitState(%s) in Registry: %v", name, err)
-			}
-		} else {
-			// Sanity check - don't want to publish incomplete UnitStates
-			// TODO(jonboulle): consider teasing apart a separate UnitState-like struct
-			// so we can rely on a UnitState always being fully hydrated?
-
-			// See https://github.com/coreos/fleet/issues/720
-			//if len(us.UnitHash) == 0 {
-			//	log.Errorf("Refusing to push UnitState(%s), no UnitHash: %#v", name, us)
-
-			if len(us.MachineID) == 0 {
-				log.Errorf("Refusing to push UnitState(%s), no MachineID: %#v", name, us)
+	return func(unitStates map[string]*unit.UnitState) {
+		states := make([]*pb.SaveUnitStateRequest, 0)
+		for name, state := range unitStates {
+			if state == nil {
+				log.Debugf("Destroying UnitState(%s) in Registry", name)
+				err := reg.RemoveUnitState(name)
+				if err != nil {
+					log.Errorf("Failed to destroy UnitState(%s) in Registry: %v", name, err)
+				}
 			} else {
-				log.Debugf("Pushing UnitState(%s) to Registry: %#v", name, us)
-				reg.SaveUnitState(name, us, ttl)
+				// Sanity check - don't want to publish incomplete UnitStates
+				// TODO(jonboulle): consider teasing apart a separate UnitState-like struct
+				// so we can rely on a UnitState always being fully hydrated?
+
+				// See https://github.com/coreos/fleet/issues/720
+				//if len(us.UnitHash) == 0
+				//	log.Errorf("Refusing to push UnitState(%s), no UnitHash: %#v", name, us)
+				if len(state.MachineID) == 0 {
+					log.Errorf("Refusing to push UnitState(%s), no MachineID: %#v", name, state)
+				} else {
+					log.Debugf("Pushing UnitState(%s) to Registry: %#v", name, state)
+					unitState := &pb.SaveUnitStateRequest{
+						Name: name,
+						State: state.ToPB(),
+						TTL: int32(ttl.Seconds()),
+					}
+					states = append(states, unitState)
+				}
 			}
 		}
+		if len(states) > 0 {
+			log.Infof("Saving states in publisher: %d", len(states))
+			reg.SaveUnitStates(states)
+		}
+
 	}
 }

--- a/agent/unit_state.go
+++ b/agent/unit_state.go
@@ -86,7 +86,7 @@ func (p *UnitStatePublisher) Run(beatchan <-chan *unit.UnitStateHeartbeats, stop
 						p.cacheMutex.Lock()
 						for name, state := range p.cache {
 							if state == nil {
-								log.Infof("Cleaning content of cache for unit %s", name)
+								log.Debugf("Cleaning content of unit hearbeat cache of %s", name)
 								delete(p.cache, name)
 							}
 						}
@@ -208,7 +208,7 @@ func newPublisher(reg registry.Registry, ttl time.Duration) publishFunc {
 			}
 		}
 		if len(states) > 0 {
-			log.Infof("Saving states in publisher: %d", len(states))
+			log.Debugf("Save %d unit states using unit publisher", len(states))
 			reg.SaveUnitStates(states)
 		}
 

--- a/protobuf/fleet.pb.go
+++ b/protobuf/fleet.pb.go
@@ -16,6 +16,7 @@
 		ScheduleUnitRequest
 		UnscheduleUnitRequest
 		SaveUnitStateRequest
+		SaveUnitStatesRequest
 		Heartbeat
 		GenericReply
 		Units
@@ -137,6 +138,20 @@ func (*SaveUnitStateRequest) ProtoMessage() {}
 func (m *SaveUnitStateRequest) GetState() *UnitState {
 	if m != nil {
 		return m.State
+	}
+	return nil
+}
+
+type SaveUnitStatesRequest struct {
+	UnitStates []*SaveUnitStateRequest `protobuf:"bytes,1,rep,name=save_unit_states" json:"save_unit_states,omitempty"`
+}
+
+func (m *SaveUnitStatesRequest) Reset()      { *m = SaveUnitStatesRequest{} }
+func (*SaveUnitStatesRequest) ProtoMessage() {}
+
+func (m *SaveUnitStatesRequest) GetUnitStates() []*SaveUnitStateRequest {
+	if m != nil {
+		return m.UnitStates
 	}
 	return nil
 }
@@ -481,6 +496,7 @@ func init() {
 	proto.RegisterType((*ScheduleUnitRequest)(nil), "rpc.ScheduleUnitRequest")
 	proto.RegisterType((*UnscheduleUnitRequest)(nil), "rpc.UnscheduleUnitRequest")
 	proto.RegisterType((*SaveUnitStateRequest)(nil), "rpc.SaveUnitStateRequest")
+	proto.RegisterType((*SaveUnitStatesRequest)(nil), "rpc.SaveUnitStatesRequest")
 	proto.RegisterType((*Heartbeat)(nil), "rpc.Heartbeat")
 	proto.RegisterType((*GenericReply)(nil), "rpc.GenericReply")
 	proto.RegisterType((*Units)(nil), "rpc.Units")
@@ -711,6 +727,36 @@ func (this *SaveUnitStateRequest) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *SaveUnitStatesRequest) Equal(that interface{}) bool {
+	if that == nil {
+		if this == nil {
+			return true
+		}
+		return false
+	}
+
+	that1, ok := that.(*SaveUnitStatesRequest)
+	if !ok {
+		return false
+	}
+	if that1 == nil {
+		if this == nil {
+			return true
+		}
+		return false
+	} else if this == nil {
+		return false
+	}
+	if len(this.UnitStates) != len(that1.UnitStates) {
+		return false
+	}
+	for i := range this.UnitStates {
+		if !this.UnitStates[i].Equal(&that1.UnitStates[i]) {
+			return false
+		}
+	}
+	return true
+}
 func (this *Heartbeat) Equal(that interface{}) bool {
 	if that == nil {
 		if this == nil {
@@ -789,36 +835,6 @@ func (this *Units) Equal(that interface{}) bool {
 	}
 	for i := range this.Units {
 		if !this.Units[i].Equal(&that1.Units[i]) {
-			return false
-		}
-	}
-	return true
-}
-func (this *UnitStates) Equal(that interface{}) bool {
-	if that == nil {
-		if this == nil {
-			return true
-		}
-		return false
-	}
-
-	that1, ok := that.(*UnitStates)
-	if !ok {
-		return false
-	}
-	if that1 == nil {
-		if this == nil {
-			return true
-		}
-		return false
-	} else if this == nil {
-		return false
-	}
-	if len(this.UnitStates) != len(that1.UnitStates) {
-		return false
-	}
-	for i := range this.UnitStates {
-		if !this.UnitStates[i].Equal(that1.UnitStates[i]) {
 			return false
 		}
 	}
@@ -1307,6 +1323,18 @@ func (this *SaveUnitStateRequest) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *SaveUnitStatesRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&rpc.SaveUnitStatesRequest{")
+	if this.UnitStates != nil {
+		s = append(s, "UnitStates: "+fmt.Sprintf("%#v", this.UnitStates)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func (this *Heartbeat) GoString() string {
 	if this == nil {
 		return "nil"
@@ -1551,6 +1579,7 @@ type RegistryClient interface {
 	// mix heartbeat with *ttl''
 	RemoveUnitState(ctx context.Context, in *UnitName, opts ...grpc.CallOption) (*GenericReply, error)
 	SaveUnitState(ctx context.Context, in *SaveUnitStateRequest, opts ...grpc.CallOption) (*GenericReply, error)
+	SaveUnitStates(ctx context.Context, in *SaveUnitStatesRequest, opts ...grpc.CallOption) (*GenericReply, error)
 	ScheduleUnit(ctx context.Context, in *ScheduleUnitRequest, opts ...grpc.CallOption) (*GenericReply, error)
 	SetUnitTargetState(ctx context.Context, in *ScheduledUnit, opts ...grpc.CallOption) (*GenericReply, error)
 	UnscheduleUnit(ctx context.Context, in *UnscheduleUnitRequest, opts ...grpc.CallOption) (*GenericReply, error)
@@ -1664,6 +1693,15 @@ func (c *registryClient) SaveUnitState(ctx context.Context, in *SaveUnitStateReq
 	return out, nil
 }
 
+func (c *registryClient) SaveUnitStates(ctx context.Context, in *SaveUnitStatesRequest, opts ...grpc.CallOption) (*GenericReply, error) {
+	out := new(GenericReply)
+	err := grpc.Invoke(ctx, "/rpc.Registry/SaveUnitStates", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *registryClient) ScheduleUnit(ctx context.Context, in *ScheduleUnitRequest, opts ...grpc.CallOption) (*GenericReply, error) {
 	out := new(GenericReply)
 	err := grpc.Invoke(ctx, "/rpc.Registry/ScheduleUnit", in, out, c.cc, opts...)
@@ -1742,6 +1780,7 @@ type RegistryServer interface {
 	// mix heartbeat with *ttl''
 	RemoveUnitState(context.Context, *UnitName) (*GenericReply, error)
 	SaveUnitState(context.Context, *SaveUnitStateRequest) (*GenericReply, error)
+	SaveUnitStates(context.Context, *SaveUnitStatesRequest) (*GenericReply, error)
 	ScheduleUnit(context.Context, *ScheduleUnitRequest) (*GenericReply, error)
 	SetUnitTargetState(context.Context, *ScheduledUnit) (*GenericReply, error)
 	UnscheduleUnit(context.Context, *UnscheduleUnitRequest) (*GenericReply, error)
@@ -1884,6 +1923,18 @@ func _Registry_SaveUnitState_Handler(srv interface{}, ctx context.Context, dec f
 	return out, nil
 }
 
+func _Registry_SaveUnitStates_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(SaveUnitStatesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(RegistryServer).SaveUnitStates(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func _Registry_ScheduleUnit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
 	in := new(ScheduleUnitRequest)
 	if err := dec(in); err != nil {
@@ -1988,6 +2039,10 @@ var _Registry_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SaveUnitState",
 			Handler:    _Registry_SaveUnitState_Handler,
+		},
+		{
+			MethodName: "SaveUnitStates",
+			Handler:    _Registry_SaveUnitStates_Handler,
 		},
 		{
 			MethodName: "ScheduleUnit",
@@ -2241,6 +2296,36 @@ func (m *SaveUnitStateRequest) MarshalTo(data []byte) (int, error) {
 		data[i] = 0x18
 		i++
 		i = encodeVarintFleet(data, i, uint64(m.TTL))
+	}
+	return i, nil
+}
+
+func (m *SaveUnitStatesRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *SaveUnitStatesRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.UnitStates) > 0 {
+		for _, msg := range m.UnitStates {
+			data[i] = 0xa
+			i++
+			i = encodeVarintFleet(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
 	}
 	return i, nil
 }
@@ -2862,6 +2947,18 @@ func (m *SaveUnitStateRequest) Size() (n int) {
 	return n
 }
 
+func (m *SaveUnitStatesRequest) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.UnitStates) > 0 {
+		for _, e := range m.UnitStates {
+			l = e.Size()
+			n += 1 + l + sovFleet(uint64(l))
+		}
+	}
+	return n
+}
+
 func (m *Heartbeat) Size() (n int) {
 	var l int
 	_ = l
@@ -3172,6 +3269,15 @@ func (this *SaveUnitStateRequest) String() string {
 		`State:` + strings.Replace(fmt.Sprintf("%v", this.State), "UnitState", "UnitState", 1) + `,`,
 		`TTL:` + fmt.Sprintf("%v", this.TTL) + `,`,
 		`}`,
+	}, "")
+	return s
+}
+func (this *SaveUnitStatesRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&SaveUnitStatesRequest{`,
+		`UnitStates:` + strings.Replace(fmt.Sprintf("%v", this.UnitStates), "UnitState", "UnitState", 1) + `,`,
 	}, "")
 	return s
 }
@@ -4161,6 +4267,87 @@ func (m *SaveUnitStateRequest) Unmarshal(data []byte) error {
 					break
 				}
 			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipFleet(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthFleet
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SaveUnitStatesRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowFleet
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SaveUnitStatesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SaveUnitStatesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SaveUnitStatesRequest", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowFleet
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthFleet
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.UnitStates = append(m.UnitStates, &SaveUnitStateRequest{})
+			if err := m.UnitStates[len(m.UnitStates)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipFleet(data[iNdEx:])

--- a/protobuf/fleet.proto
+++ b/protobuf/fleet.proto
@@ -13,16 +13,17 @@ service Registry {
 	rpc GetScheduledUnit(UnitName) returns (MaybeScheduledUnit);
 	// should _never_ be used ?
 	rpc GetUnit(UnitName) returns (MaybeUnit);
-	rpc GetUnits(UnitFilter) returns (Units); // => global status ? 
+	rpc GetUnits(UnitFilter) returns (Units); // => global status ?
 	// global status <= pretty much like list-unit-files
 	rpc GetUnitStates(UnitStateFilter) returns (UnitStates);
 	rpc ClearUnitHeartbeat(UnitName) returns (GenericReply);
 	rpc CreateUnit(Unit) returns (GenericReply);
 	rpc DestroyUnit(UnitName) returns (GenericReply);
 	rpc UnitHeartbeat(Heartbeat) returns (GenericReply);
-	// mix heartbeat with *ttl'' 
+	// mix heartbeat with *ttl''
 	rpc RemoveUnitState(UnitName) returns (GenericReply);
 	rpc SaveUnitState(SaveUnitStateRequest) returns (GenericReply);
+	rpc SaveUnitStates(SaveUnitStatesRequest) returns (GenericReply);
 	rpc ScheduleUnit(ScheduleUnitRequest) returns (GenericReply);
 	rpc SetUnitTargetState(ScheduledUnit) returns (GenericReply);
 	rpc UnscheduleUnit(UnscheduleUnitRequest) returns (GenericReply);
@@ -75,7 +76,11 @@ message SaveUnitStateRequest {
 	string    name  = 1;
 	UnitState state = 2;
 	int32     ttl   = 3 [(gogoproto.customname) = "TTL"];
-	// machine 
+	// machine
+}
+
+message SaveUnitStatesRequest {
+	repeated SaveUnitStateRequest save_unit_states = 1;
 }
 
 message Heartbeat {
@@ -154,5 +159,3 @@ message UnitOption {
 	string name    = 2;
 	string value   = 3;
 }
-
-

--- a/registry/fake.go
+++ b/registry/fake.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/pkg/lease"
 	"github.com/coreos/fleet/unit"
+	pb "github.com/coreos/fleet/protobuf"
 )
 
 func NewFakeRegistry() *FakeRegistry {
@@ -240,6 +241,25 @@ func (f *FakeRegistry) SaveUnitState(jobName string, unitState *unit.UnitState, 
 		f.jobStates[jobName] = make(map[string]*unit.UnitState)
 	}
 	f.jobStates[jobName][unitState.MachineID] = unitState
+}
+
+func (f *FakeRegistry) SaveUnitStates(unitStates []*pb.SaveUnitStateRequest) {
+	defer f.Unlock()
+	for _, us := range unitStates {
+		name := us.Name
+		if us.State.Name != "" {
+			name = us.State.Name
+		}
+		state := &unit.UnitState {
+			LoadState: us.State.LoadState,
+			ActiveState: us.State.ActiveState,
+			SubState: us.State.SubState,
+			MachineID: us.State.MachineID,
+			UnitHash: us.State.Hash,
+			UnitName: name,
+		}
+		f.SaveUnitState(name, state, time.Duration(us.TTL) * time.Second)
+	}
 }
 
 func (f *FakeRegistry) RemoveUnitState(jobName string) error {

--- a/registry/inmemory.go
+++ b/registry/inmemory.go
@@ -230,6 +230,15 @@ func (r *inmemoryRegistry) SaveUnitState(unitName string, state *pb.UnitState, t
 	}
 }
 
+func (r *inmemoryRegistry) SaveUnitStates(unitStates []*pb.SaveUnitStateRequest) {
+	if DebugInmemoryRegistry {
+		defer debug.Exit_(debug.Enter_(unitStates))
+	}
+	for _, us := range unitStates {
+		r.SaveUnitState(us.Name, us.State, time.Duration(us.TTL) * time.Second)
+	}
+}
+
 func (r *inmemoryRegistry) UnitHeartbeat(unitName, machineid string, ttl time.Duration) {
 	if DebugInmemoryRegistry {
 		defer debug.Exit_(debug.Enter_(unitName, machineid, ttl))

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/unit"
+	pb "github.com/coreos/fleet/protobuf"
 )
 
 type Registry interface {
@@ -33,6 +34,7 @@ type Registry interface {
 	RemoveMachineState(machID string) error
 	RemoveUnitState(jobName string) error
 	SaveUnitState(jobName string, unitState *unit.UnitState, ttl time.Duration)
+	SaveUnitStates(unitStates []*pb.SaveUnitStateRequest)
 	ScheduleUnit(name, machID string) error
 	SetUnitTargetState(name string, state job.JobState) error
 	SetMachineState(ms machine.MachineState, ttl time.Duration) (uint64, error)

--- a/registry/registrymux.go
+++ b/registry/registrymux.go
@@ -12,6 +12,8 @@ import (
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/unit"
+	pb "github.com/coreos/fleet/protobuf"
+
 )
 
 type RegistryMux struct {
@@ -136,6 +138,10 @@ func (r *RegistryMux) RemoveUnitState(jobName string) error {
 
 func (r *RegistryMux) SaveUnitState(jobName string, unitState *unit.UnitState, ttl time.Duration) {
 	r.getRegistry().SaveUnitState(jobName, unitState, ttl)
+}
+
+func (r *RegistryMux) SaveUnitStates(unitStates []*pb.SaveUnitStateRequest) {
+	r.getRegistry().SaveUnitStates(unitStates)
 }
 
 func (r *RegistryMux) ScheduleUnit(name string, machID string) error {

--- a/registry/rpcregistry.go
+++ b/registry/rpcregistry.go
@@ -138,6 +138,12 @@ func (r *RPCRegistry) SaveUnitState(unitName string, unitState *unit.UnitState, 
 	})
 }
 
+func (r *RPCRegistry) SaveUnitStates(unitStates []*pb.SaveUnitStateRequest) {
+	r.getClient().SaveUnitStates(r.ctx(), &pb.SaveUnitStatesRequest{
+		UnitStates: unitStates,
+	})
+}
+
 func (r *RPCRegistry) ScheduleUnit(unitName, machID string) error {
 	if DebugRPCRegistry {
 		defer debug.Exit_(debug.Enter_(unitName, machID))

--- a/registry/rpcserver.go
+++ b/registry/rpcserver.go
@@ -189,6 +189,14 @@ func (s *rpcserver) SaveUnitState(ctx context.Context, req *pb.SaveUnitStateRequ
 	return &pb.GenericReply{}, nil
 }
 
+func (s *rpcserver) SaveUnitStates(ctx context.Context, req *pb.SaveUnitStatesRequest) (*pb.GenericReply, error) {
+	if debugRPCServer {
+		defer debug.Exit_(debug.Enter_(req))
+	}
+	s.localRegistry.SaveUnitStates(req.UnitStates)
+	return &pb.GenericReply{}, nil
+}
+
 func (s *rpcserver) ScheduleUnit(ctx context.Context, unit *pb.ScheduleUnitRequest) (*pb.GenericReply, error) {
 	if debugRPCServer {
 		defer debug.Exit_(debug.Enter_(unit.Name, unit.MachineID))

--- a/server/server.go
+++ b/server/server.go
@@ -184,7 +184,7 @@ func (s *Server) Run() {
 		go s.engine.Run(s.engineReconcileInterval, s.stop)
 	}
 
-	beatchan := make(chan *unit.UnitStateHeartbeat)
+	beatchan := make(chan *unit.UnitStateHeartbeats)
 	go s.usGen.Run(beatchan, s.stop)
 	go s.usPub.Run(beatchan, s.stop)
 }

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease registry systemd unit"
+TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease ssh registry systemd unit"
 FORMATTABLE="$TESTABLE client functional functional/platform heart server fleetd"
 
 # user has not provided PKG override

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease ssh registry systemd unit"
+TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease registry ssh systemd unit"
 FORMATTABLE="$TESTABLE client functional functional/platform heart server fleetd"
 
 # user has not provided PKG override

--- a/test
+++ b/test
@@ -14,7 +14,7 @@ COVER=${COVER:-"-cover"}
 
 source ./build
 
-TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease registry ssh systemd unit"
+TESTABLE="agent api config engine fleetctl job machine pkg pkg/lease registry systemd unit"
 FORMATTABLE="$TESTABLE client functional functional/platform heart server fleetd"
 
 # user has not provided PKG override

--- a/unit/generator.go
+++ b/unit/generator.go
@@ -27,6 +27,10 @@ type UnitStateHeartbeat struct {
 	State *UnitState
 }
 
+type UnitStateHeartbeats struct {
+	States []*UnitStateHeartbeat
+}
+
 func NewUnitStateGenerator(mgr UnitManager) *UnitStateGenerator {
 	return &UnitStateGenerator{
 		mgr:        mgr,
@@ -53,7 +57,7 @@ func (g *UnitStateGenerator) MarshalJSON() ([]byte, error) {
 
 // Run periodically calls Generate and sends received *UnitStateHeartbeat
 // objects to the provided channel.
-func (g *UnitStateGenerator) Run(receiver chan<- *UnitStateHeartbeat, stop chan bool) {
+func (g *UnitStateGenerator) Run(receiver chan<- *UnitStateHeartbeats, stop chan bool) {
 	tick := time.Tick(time.Second)
 	for {
 		select {
@@ -75,7 +79,7 @@ func (g *UnitStateGenerator) Run(receiver chan<- *UnitStateHeartbeat, stop chan 
 
 // Generate returns and fills a channel with *UnitStateHeartbeat objects. Objects will
 // only be returned for units to which this generator is currently subscribed.
-func (g *UnitStateGenerator) Generate() (<-chan *UnitStateHeartbeat, error) {
+func (g *UnitStateGenerator) Generate() (<-chan *UnitStateHeartbeats, error) {
 	var lastSubscribed pkg.Set
 	if g.lastSubscribed != nil {
 		lastSubscribed = g.lastSubscribed.Copy()
@@ -89,14 +93,17 @@ func (g *UnitStateGenerator) Generate() (<-chan *UnitStateHeartbeat, error) {
 		return nil, err
 	}
 
-	beatchan := make(chan *UnitStateHeartbeat)
+	beatchan := make(chan *UnitStateHeartbeats)
 	go func() {
+		reports := make([]*UnitStateHeartbeat, 0)
 		for name, us := range reportable {
-			us := us
-			beatchan <- &UnitStateHeartbeat{
+			us.UnitName = name
+			heartbeat := &UnitStateHeartbeat{
 				Name:  name,
 				State: us,
 			}
+			reports = append(reports, heartbeat)
+
 		}
 
 		if lastSubscribed != nil {
@@ -104,10 +111,15 @@ func (g *UnitStateGenerator) Generate() (<-chan *UnitStateHeartbeat, error) {
 			// last time Generate ran, but are now not part of that
 			// list, send nil-State heartbeats to signal removal
 			for _, name := range lastSubscribed.Sub(subscribed).Values() {
-				beatchan <- &UnitStateHeartbeat{
+				heartbeat := &UnitStateHeartbeat{
 					Name: name,
 				}
+				reports = append(reports, heartbeat)
 			}
+		}
+
+		beatchan <- &UnitStateHeartbeats{
+			States: reports,
 		}
 
 		close(beatchan)


### PR DESCRIPTION
Related to: https://github.com/giantswarm/giantswarm/issues/495

We reduce the amount of msg exchanged during the periods of no activity or minimal, as well as we also reduce the amount of msg exchanged when adding many units concurrently...

Average message size 8 bytes per unit heartbeat.

In one of my experiments, I used 2 fleemmer clients to deploy 1800 units (900 units on each fleemmer client) on a 3-node cluster, I measured the amount of messages exchanged between nodes with the following raw result:
- Current implementation: 
  - node1: 1182 msgs
  - node2: 1077 msgs 
  - node3: 1319 msgs 
- New implementation: 
  - node1: 105 msgs 
  - node2: 100 msgs 
  - node3: 102 msgs

```
@htr did some tests comparing this PR with engine_changes (https://github.com/giantswarm/fleet/tree/engine_changes) which is the one using the old mechanism.

engine_changes
_____________ 10nodes           20nodes         50nodes
0 units       35kbyte/s         120kbyte/s      700kbyte/s
50 units      60kbyte/s         200kbyte/s      850kbyte/s
100 units     100kbyte/s        280kbyte/s      950kbyte/s


gprc_unitState_sharing
_____________ 10nodes           20nodes         50nodes
0 units       5kbyte/s          12kbyte/s       25kbyte/s
50 units      25kbyte/s         50kbyte/s       85kbyte/s
100 units     40kbyte/s         60kbyte/s       160kbyte/s
```

ping @htr 
