### PR TITLE
Disable gRPC communication by default

### DIFF
--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -81,7 +81,7 @@ func main() {
 	cfgset.String("metadata", "", "List of key-value metadata to assign to the fleet machine")
 	cfgset.String("agent_ttl", agent.DefaultTTL, "TTL in seconds of fleet machine state in etcd")
 	cfgset.Int("token_limit", 100, "Maximum number of entries per page returned from API requests")
-	cfgset.Bool("enable_grpc", true, "When possible, uses grpc to communicate between engine and agent")
+	cfgset.Bool("enable_grpc", false, "When possible, uses grpc to communicate between engine and agent")
 	cfgset.Bool("disable_engine", false, "Disable the engine entirely, use with care")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")

--- a/registry/job.go
+++ b/registry/job.go
@@ -70,8 +70,8 @@ func (r *EtcdRegistry) Schedule() ([]job.ScheduledUnit, error) {
 	for name, su := range uMap {
 		sortable = append(sortable, name)
 		key := MUSKey{
-			machID: su.TargetMachineID,
-			name:   name,
+			MachID: su.TargetMachineID,
+			Name:   name,
 		}
 		us := states[key]
 		js := determineJobState(heartbeats[name], su.TargetMachineID, us)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -24,7 +24,7 @@ func marshal(obj interface{}) (string, error) {
 	if err == nil {
 		return string(encoded), nil
 	}
-	return "", fmt.Errorf("Unable to JSON-serialize object: %s", err)
+	return "", fmt.Errorf("unable to JSON-serialize object: %s", err)
 }
 
 func unmarshal(val string, obj interface{}) error {
@@ -32,5 +32,5 @@ func unmarshal(val string, obj interface{}) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("Unable to JSON-deserialize object: %s", err)
+	return fmt.Errorf("unable to JSON-deserialize object: %s", err)
 }

--- a/registry/rpc/inmemory.go
+++ b/registry/rpc/inmemory.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"net/http"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/fleet/debug"
 	pb "github.com/coreos/fleet/protobuf"
+	"github.com/coreos/fleet/registry"
 )
 
 var DebugInmemoryRegistry bool = false
@@ -45,7 +46,7 @@ func init() {
 
 var currentReg *inmemoryRegistry
 
-func (r *inmemoryRegistry) LoadFrom(reg UnitRegistry) error {
+func (r *inmemoryRegistry) LoadFrom(reg registry.UnitRegistry) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	units, err := reg.Units()
@@ -141,7 +142,7 @@ func (r *inmemoryRegistry) UnitStates() []*pb.UnitState {
 	states := []*pb.UnitState{}
 	mus := r.statesByMUSKey()
 
-	var sorted MUSKeys
+	var sorted registry.MUSKeys
 	for key := range mus {
 		sorted = append(sorted, key)
 	}
@@ -293,15 +294,15 @@ func (r *inmemoryRegistry) CreateUnit(u *pb.Unit) {
 	r.unitsCache[u.Name] = *u
 }
 
-func (r *inmemoryRegistry) statesByMUSKey() map[MUSKey]*pb.UnitState {
-	states := map[MUSKey]*pb.UnitState{}
+func (r *inmemoryRegistry) statesByMUSKey() map[registry.MUSKey]*pb.UnitState {
+	states := map[registry.MUSKey]*pb.UnitState{}
 
 	for unitname, unitStates := range r.unitStates {
 		for machineID, heartbeat := range unitStates {
 			if heartbeat.isValid() {
-				k := MUSKey{
-					name:   unitname,
-					machID: machineID,
+				k := registry.MUSKey{
+					Name:   unitname,
+					MachID: machineID,
 				}
 				s := *heartbeat.state
 				states[k] = &s

--- a/registry/rpc/inmemory_dbg.go
+++ b/registry/rpc/inmemory_dbg.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"encoding/json"

--- a/registry/rpc/inmemory_test.go
+++ b/registry/rpc/inmemory_test.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"testing"

--- a/registry/rpc/registrymux.go
+++ b/registry/rpc/registrymux.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"fmt"
@@ -11,14 +11,15 @@ import (
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/unit"
 )
 
 type RegistryMux struct {
-	etcdRegistry    *EtcdRegistry
+	etcdRegistry    *registry.EtcdRegistry
 	localMachine    machine.Machine
 	rpcserver       *rpcserver
-	currentRegistry Registry
+	currentRegistry registry.Registry
 	rpcRegistry     *RPCRegistry
 	currentEngine   machine.MachineState
 
@@ -27,7 +28,7 @@ type RegistryMux struct {
 
 const dialRegistryReconnectTimeout = 200 * time.Millisecond
 
-func NewRegistryMux(etcdRegistry *EtcdRegistry, localMachine machine.Machine) *RegistryMux {
+func NewRegistryMux(etcdRegistry *registry.EtcdRegistry, localMachine machine.Machine) *RegistryMux {
 	return &RegistryMux{
 		etcdRegistry:         etcdRegistry,
 		localMachine:         localMachine,
@@ -93,7 +94,7 @@ func (r *RegistryMux) EngineChanged(newEngine machine.MachineState) {
 	}
 }
 
-func (r *RegistryMux) getRegistry() Registry {
+func (r *RegistryMux) getRegistry() registry.Registry {
 	r.handlingEngineChange.RLock()
 	defer r.handlingEngineChange.RUnlock()
 	if r.currentRegistry == nil {

--- a/registry/rpc/registrymux_test.go
+++ b/registry/rpc/registrymux_test.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"io/ioutil"

--- a/registry/rpc/rpcregistry.go
+++ b/registry/rpc/rpcregistry.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"errors"

--- a/registry/rpc/rpcregistry_test.go
+++ b/registry/rpc/rpcregistry_test.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"net"

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"errors"
@@ -13,6 +13,7 @@ import (
 	"github.com/coreos/fleet/debug"
 	"github.com/coreos/fleet/log"
 	pb "github.com/coreos/fleet/protobuf"
+	"github.com/coreos/fleet/registry"
 )
 
 var debugRPCServer bool = false
@@ -24,7 +25,7 @@ const (
 )
 
 type rpcserver struct {
-	etcdRegistry Registry
+	etcdRegistry registry.Registry
 	mu           *sync.Mutex
 	listener     net.Listener
 	grpcserver   *grpc.Server
@@ -33,7 +34,7 @@ type rpcserver struct {
 	localRegistry *inmemoryRegistry
 }
 
-func NewRPCServer(reg Registry, addr string) (*rpcserver, error) {
+func NewRPCServer(reg registry.Registry, addr string) (*rpcserver, error) {
 	s := &rpcserver{
 		etcdRegistry:  reg,
 		mu:            new(sync.Mutex),

--- a/registry/rpc/rpcutils.go
+++ b/registry/rpc/rpcutils.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	sdunit "github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-systemd/unit"

--- a/registry/rpc/rpcutils_test.go
+++ b/registry/rpc/rpcutils_test.go
@@ -1,4 +1,4 @@
-package registry
+package rpc
 
 import (
 	"reflect"

--- a/registry/unit_state.go
+++ b/registry/unit_state.go
@@ -76,8 +76,8 @@ func (r *EtcdRegistry) UnitStates() (states []*unit.UnitState, err error) {
 
 // MUSKey is used to index UnitStates by name + machineID
 type MUSKey struct {
-	name   string
-	machID string
+	Name   string
+	MachID string
 }
 
 // MUSKeys provides for sorting of UnitStates by their MUSKey
@@ -87,7 +87,7 @@ func (mk MUSKeys) Len() int { return len(mk) }
 func (mk MUSKeys) Less(i, j int) bool {
 	mi := mk[i]
 	mj := mk[j]
-	return mi.name < mj.name || (mi.name == mj.name && mi.machID < mj.machID)
+	return mi.Name < mj.Name || (mi.Name == mj.Name && mi.MachID < mj.MachID)
 }
 func (mk MUSKeys) Swap(i, j int) { mk[i], mk[j] = mk[j], mk[i] }
 

--- a/registry/unit_state_test.go
+++ b/registry/unit_state_test.go
@@ -515,11 +515,11 @@ func TestMUSKeys(t *testing.T) {
 		}
 		return true
 	}
-	k1 := MUSKey{name: "abc", machID: "aaa"}
-	k2 := MUSKey{name: "abc", machID: "zzz"}
-	k3 := MUSKey{name: "def", machID: "bbb"}
-	k4 := MUSKey{name: "ppp", machID: "zzz"}
-	k5 := MUSKey{name: "xxx", machID: "aaa"}
+	k1 := MUSKey{Name: "abc", MachID: "aaa"}
+	k2 := MUSKey{Name: "abc", MachID: "zzz"}
+	k3 := MUSKey{Name: "def", MachID: "bbb"}
+	k4 := MUSKey{Name: "ppp", MachID: "zzz"}
+	k5 := MUSKey{Name: "xxx", MachID: "aaa"}
 	want := []MUSKey{k1, k2, k3, k4, k5}
 	ms := MUSKeys{k3, k4, k5, k2, k1}
 	if equal(ms, want) {

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/fleet/pkg"
 	"github.com/coreos/fleet/pkg/lease"
 	"github.com/coreos/fleet/registry"
+	"github.com/coreos/fleet/registry/rpc"
 	"github.com/coreos/fleet/systemd"
 	"github.com/coreos/fleet/unit"
 	"github.com/coreos/fleet/version"
@@ -93,8 +94,23 @@ func New(cfg config.Config) (*Server, error) {
 
 	etcdRequestTimeout := time.Duration(cfg.EtcdRequestTimeout*1000) * time.Millisecond
 	kAPI := etcd.NewKeysAPI(eClient)
-	etcdReg := registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
-	reg := registry.NewRegistryMux(etcdReg, mach)
+
+	var (
+		reg        engine.CompleteRegistry
+		genericReg interface{}
+	)
+	if !cfg.EnableGRPC {
+		genericReg = registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
+		if obj, ok := genericReg.(engine.CompleteRegistry); ok {
+			reg = obj
+		}
+	} else {
+		etcdReg := registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
+		genericReg = rpc.NewRegistryMux(etcdReg, mach)
+		if obj, ok := genericReg.(engine.CompleteRegistry); ok {
+			reg = obj
+		}
+	}
 
 	pub := agent.NewUnitStatePublisher(reg, mach, agentTTL)
 	gen := unit.NewUnitStateGenerator(mgr)
@@ -106,7 +122,13 @@ func New(cfg config.Config) (*Server, error) {
 
 	ar := agent.NewReconciler(reg, rStream)
 
-	e := engine.New(reg, lManager, rStream, mach, reg.EngineChanged)
+	var e *engine.Engine
+	if !cfg.EnableGRPC {
+		e = engine.New(reg, lManager, rStream, mach, nil, cfg.EnableGRPC)
+	} else {
+		regMux := genericReg.(*rpc.RegistryMux)
+		e = engine.New(reg, lManager, rStream, mach, regMux.EngineChanged, cfg.EnableGRPC)
+	}
 
 	listeners, err := activation.Listeners(false)
 	if err != nil {


### PR DESCRIPTION
Related to: https://github.com/giantswarm/giantswarm/issues/494

This PR aims to keep the default fleet implementation and use only our GRPC code whenever `enable_grpc` is true. This means that our `registrymux` is not working as before, thereby two different fleet versions (etcd and grpc) cannot leave together.

Implementation wise, I used the flag in few places and relocated our `grpc` code in a different directory to help the reader differ our new implementation from the current one.

To sum up:
`enable_grpc`: false == Old way of working or in other words only etcd 
`enable_grpc`: true == Use GRPC registry (registrymux). I keep registrymux even if we aren't willing at this moment to be able to have two diff implementations, in order to merge our upstream PR asap.

ping @htr @teemow
