### PR TITLE
Add support to handle different engine configurations

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -45,7 +45,6 @@ type Engine struct {
 	trigger chan struct{}
 
 	updateEngineState func(newEngine machine.MachineState)
-	enableGRPC        bool
 }
 
 type CompleteRegistry interface {
@@ -53,7 +52,7 @@ type CompleteRegistry interface {
 	registry.ClusterRegistry
 }
 
-func New(reg CompleteRegistry, lManager lease.Manager, rStream pkg.EventStream, mach machine.Machine, updateEngineState func(newEngine machine.MachineState), enableGRPC bool) *Engine {
+func New(reg CompleteRegistry, lManager lease.Manager, rStream pkg.EventStream, mach machine.Machine, updateEngineState func(newEngine machine.MachineState)) *Engine {
 	rec := NewReconciler()
 	return &Engine{
 		rec:               rec,
@@ -64,7 +63,6 @@ func New(reg CompleteRegistry, lManager lease.Manager, rStream pkg.EventStream, 
 		machine:           mach,
 		trigger:           make(chan struct{}),
 		updateEngineState: updateEngineState,
-		enableGRPC:        enableGRPC,
 	}
 }
 
@@ -77,7 +75,7 @@ func (e *Engine) Run(ival time.Duration, stop chan bool) {
 			return
 		}
 
-		if e.enableGRPC {
+		if e.machine.State().Capabilities.Has(machine.CapGRPC) {
 			// rpcLeadership gets the lease (leader), and apply changes to the engine state if need it.
 			e.lease = e.rpcLeadership(leaseTTL, machID)
 		} else {

--- a/registry/rpc/registrymux.go
+++ b/registry/rpc/registrymux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/pkg/lease"
 	"github.com/coreos/fleet/registry"
 	"github.com/coreos/fleet/unit"
 )
@@ -23,17 +24,76 @@ type RegistryMux struct {
 	currentRegistry registry.Registry
 	rpcRegistry     *RPCRegistry
 	currentEngine   machine.MachineState
+	leaseManager    lease.Manager
 
 	handlingEngineChange *sync.RWMutex
 }
 
-const dialRegistryReconnectTimeout = 200 * time.Millisecond
+const (
+	dialRegistryReconnectTimeout = 200 * time.Millisecond
 
-func NewRegistryMux(etcdRegistry *registry.EtcdRegistry, localMachine machine.Machine) *RegistryMux {
+	engineLeaderKeyPath = "engine-leader"
+)
+
+func NewRegistryMux(etcdRegistry *registry.EtcdRegistry, localMachine machine.Machine, leaseManager lease.Manager) *RegistryMux {
 	return &RegistryMux{
 		etcdRegistry:         etcdRegistry,
 		localMachine:         localMachine,
 		handlingEngineChange: new(sync.RWMutex),
+		leaseManager:         leaseManager,
+	}
+}
+
+func (r *RegistryMux) ConnectRPCRegistry() {
+	if r.rpcRegistry != nil && r.rpcRegistry.IsRegistryReady() {
+		log.Infof("Reusing gRPC engine, connection is READY\n")
+		r.currentRegistry = r.rpcRegistry
+	} else {
+		log.Infof("New engine supports gRPC, connecting\n")
+		r.rpcRegistry = NewRPCRegistry(r.rpcDialerNoEngine)
+		// connect to rpc registry
+		r.rpcRegistry.Connect()
+		r.currentRegistry = r.rpcRegistry
+	}
+}
+
+func (r *RegistryMux) rpcDialerNoEngine(_ string, timeout time.Duration) (net.Conn, error) {
+	ticker := time.Tick(dialRegistryReconnectTimeout)
+	// Timeout re-defined to call etcd every 3secs to get the leader
+	timeout = 3 * time.Second
+	check := time.After(timeout)
+
+	for {
+		select {
+		case <-check:
+			log.Errorf("Unable to connect to engine %s\n", r.currentEngine.PublicIP)
+			// Get the new engine leader of the cluster out of etcd
+			lease, err := r.leaseManager.GetLease(engineLeaderKeyPath)
+			// Key found
+			if err == nil {
+				var err error
+				machines, err := r.getRegistry().Machines()
+				if err != nil {
+					log.Errorf("Unable to get the machines of the cluster %v\n", err)
+					return nil, errors.New("Unable to get the machines of the cluster")
+				}
+				for _, s := range machines {
+					if s.ID == lease.MachineID() {
+						r.currentEngine = s
+						log.Infof("Found a new engine to connect %s\n", r.currentEngine.PublicIP)
+					}
+				}
+				check = time.After(timeout)
+			}
+		case <-ticker:
+			addr := fmt.Sprintf("%s:%d", r.currentEngine.PublicIP, rpcServerPort)
+			conn, err := net.Dial("tcp", addr)
+			if err == nil {
+				log.Infof("Connected to engine on %s\n", r.currentEngine.PublicIP)
+				return conn, nil
+			}
+			log.Errorf("Retry to connect to new engine: %+v", err)
+		}
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -99,6 +99,8 @@ func New(cfg config.Config) (*Server, error) {
 		reg        engine.CompleteRegistry
 		genericReg interface{}
 	)
+	lManager := lease.NewEtcdLeaseManager(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
+
 	if !cfg.EnableGRPC {
 		genericReg = registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
 		if obj, ok := genericReg.(engine.CompleteRegistry); ok {
@@ -106,7 +108,7 @@ func New(cfg config.Config) (*Server, error) {
 		}
 	} else {
 		etcdReg := registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
-		genericReg = rpc.NewRegistryMux(etcdReg, mach)
+		genericReg = rpc.NewRegistryMux(etcdReg, mach, lManager)
 		if obj, ok := genericReg.(engine.CompleteRegistry); ok {
 			reg = obj
 		}
@@ -118,16 +120,18 @@ func New(cfg config.Config) (*Server, error) {
 	a := agent.New(mgr, gen, reg, mach, agentTTL)
 
 	rStream := registry.NewEtcdEventStream(kAPI, cfg.EtcdKeyPrefix)
-	lManager := lease.NewEtcdLeaseManager(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
 
 	ar := agent.NewReconciler(reg, rStream)
 
 	var e *engine.Engine
 	if !cfg.EnableGRPC {
-		e = engine.New(reg, lManager, rStream, mach, nil, cfg.EnableGRPC)
+		e = engine.New(reg, lManager, rStream, mach, nil)
 	} else {
 		regMux := genericReg.(*rpc.RegistryMux)
-		e = engine.New(reg, lManager, rStream, mach, regMux.EngineChanged, cfg.EnableGRPC)
+		e = engine.New(reg, lManager, rStream, mach, regMux.EngineChanged)
+		if cfg.DisableEngine {
+			regMux.ConnectRPCRegistry()
+		}
 	}
 
 	listeners, err := activation.Listeners(false)


### PR DESCRIPTION
This PR aims to add support for the following configurations:

grpc: enabled
engine: enabled

grpc: disabled
engine: disabled

The next configuration wasn't supported yet.
grpc: enabled
engine: disabled

**Note**: For the migration from an etcd cluster to a grpc cluster, It is really **CRITICAL** to stop the fleet leader of an old etcd cluster, at the END. It has to be the last one to stop. We do so in order to keep the other nodes to use the etcd backend as long as there is an etcd leader, and once this is GONE, a new GRPC server-leader would be activated.
