### PR TITLE
Merge grpc and etcd unit states

### DIFF
--- a/registry/rpc/registrymux.go
+++ b/registry/rpc/registrymux.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coreos/fleet/Godeps/_workspace/src/github.com/coreos/go-semver/semver"
 
+	"github.com/coreos/fleet/engine"
 	"github.com/coreos/fleet/job"
 	"github.com/coreos/fleet/log"
 	"github.com/coreos/fleet/machine"
@@ -44,16 +45,33 @@ func NewRegistryMux(etcdRegistry *registry.EtcdRegistry, localMachine machine.Ma
 	}
 }
 
-func (r *RegistryMux) ConnectRPCRegistry() {
-	if r.rpcRegistry != nil && r.rpcRegistry.IsRegistryReady() {
-		log.Infof("Reusing gRPC engine, connection is READY\n")
-		r.currentRegistry = r.rpcRegistry
-	} else {
-		log.Infof("New engine supports gRPC, connecting\n")
-		r.rpcRegistry = NewRPCRegistry(r.rpcDialerNoEngine)
-		// connect to rpc registry
-		r.rpcRegistry.Connect()
-		r.currentRegistry = r.rpcRegistry
+// ConnectToRegistry allows to disable_engine fleet agents to adapt its Registry
+// to fleet leader changes regardless of whether is etcd or gRPC based.
+func (r *RegistryMux) ConnectToRegistry(e *engine.Engine) {
+	for {
+		// We have to check if the leader has changed to etcd otherwise keep grpc connection
+		if e.IsGrpcLeader() {
+			if r.rpcRegistry != nil && r.rpcRegistry.IsRegistryReady() {
+				log.Infof("Reusing gRPC engine, connection is READY\n")
+				r.currentRegistry = r.rpcRegistry
+			} else {
+				if r.rpcRegistry != nil {
+					r.rpcRegistry.Close()
+				}
+				log.Infof("New engine supports gRPC, connecting\n")
+				r.rpcRegistry = NewRPCRegistry(r.rpcDialerNoEngine)
+				// connect to rpc registry
+				r.rpcRegistry.Connect()
+				r.currentRegistry = r.rpcRegistry
+			}
+		} else {
+			if r.rpcRegistry != nil {
+				r.rpcRegistry.Close()
+			}
+			// new leader is etcd-based
+			r.currentRegistry = r.etcdRegistry
+		}
+		time.Sleep(5 * time.Second)
 	}
 }
 
@@ -81,6 +99,11 @@ func (r *RegistryMux) rpcDialerNoEngine(_ string, timeout time.Duration) (net.Co
 					// Update the currentEngine with the new one... otherwise wait until
 					// there is one
 					if s.ID == lease.MachineID() {
+						// New leader has not gRPC capabilities enabled.
+						if !s.Capabilities.Has(machine.CapGRPC) {
+							log.Error("New leader engine has not gRPC enabled!")
+							return nil, errors.New("New leader engine has not gRPC enabled!")
+						}
 						r.currentEngine = s
 						log.Infof("Found a new engine to connect to: %s\n", r.currentEngine.PublicIP)
 						// Restore initial check configuration
@@ -170,6 +193,10 @@ func (r *RegistryMux) EngineChanged(newEngine machine.MachineState) {
 			}
 		} else {
 			log.Infof("Falling back to etcd registry\n")
+			if r.rpcserver != nil {
+				// If the engine changed to a non gRPC leader, we need to stop the server
+				r.rpcserver.Stop()
+			}
 			r.currentRegistry = r.etcdRegistry
 		}
 

--- a/registry/rpc/rpcregistry.go
+++ b/registry/rpc/rpcregistry.go
@@ -86,6 +86,10 @@ func (r *RPCRegistry) Connect() {
 	log.Info("Connected succesfully to fleet-engine via grpc!")
 }
 
+func (r *RPCRegistry) Close() {
+	r.registryConn.Close()
+}
+
 func (r *RPCRegistry) IsRegistryReady() bool {
 	if r.registryConn != nil {
 		st, err := r.registryConn.State()

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -161,9 +161,8 @@ func (s *rpcserver) GetUnits(ctx context.Context, filter *pb.UnitFilter) (*pb.Un
 	units = append(units, s.localRegistry.Units()...)
 
 	if s.hasNonGRPCAgents {
-		log.Info("Merging etcd units in GetUnits()")
+		log.Debug("Merging etcd with inmemory units in GetUnits()")
 		etcdUnits, _ := s.etcdRegistry.Units()
-		log.Infof("rpcserver etcdUnits %v", etcdUnits)
 
 		unitNames := make(map[string]struct{}, len(units))
 		for _, unit := range units {
@@ -174,7 +173,6 @@ func (s *rpcserver) GetUnits(ctx context.Context, filter *pb.UnitFilter) (*pb.Un
 				units = append(units, unit.ToPB())
 			}
 		}
-		log.Infof("rpcserver etcdUnits allUnits %v", units)
 	}
 
 	return &pb.Units{Units: units}, nil
@@ -188,9 +186,8 @@ func (s *rpcserver) GetUnitStates(ctx context.Context, filter *pb.UnitStateFilte
 	states = append(states, s.localRegistry.UnitStates()...)
 
 	if s.hasNonGRPCAgents {
-		log.Info("Merging etcd unit states in GetUnitStates()")
+		log.Debug("Merging etcd with inmemory unit states in GetUnitStates()")
 		etcdUnitStates, _ := s.etcdRegistry.UnitStates()
-		log.Infof("rpcserver etcdUnitStates %v", etcdUnitStates)
 
 		unitStateNames := make(map[string]string, len(states))
 		for _, state := range states {
@@ -202,7 +199,6 @@ func (s *rpcserver) GetUnitStates(ctx context.Context, filter *pb.UnitStateFilte
 				states = append(states, state.ToPB())
 			}
 		}
-		log.Infof("rpcserver GetUnitStates allUnitStatess %v", states)
 	}
 
 	return &pb.UnitStates{states}, nil
@@ -256,7 +252,6 @@ func (s *rpcserver) RemoveUnitState(ctx context.Context, name *pb.UnitName) (*pb
 	}
 
 	if s.hasNonGRPCAgents {
-		log.Info("Merging etcd unit states in RemoveUnitState()")
 		s.etcdRegistry.RemoveUnitState(name.Name)
 	}
 
@@ -270,7 +265,6 @@ func (s *rpcserver) SaveUnitState(ctx context.Context, req *pb.SaveUnitStateRequ
 	}
 
 	if s.hasNonGRPCAgents {
-		log.Info("Merging etcd unit states in SaveUnitState()")
 		unitState := rpcUnitStateToExtUnitState(req.State)
 		s.etcdRegistry.SaveUnitState(req.Name, unitState, time.Duration(req.TTL)*time.Second)
 	}

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -72,7 +72,10 @@ func NewRPCServer(reg registry.Registry, addr string) (*rpcserver, error) {
 
 	s.SetServingStatus(pb.HealthCheckResponse_NOT_SERVING)
 
-	machineStates, _ := s.etcdRegistry.Machines()
+	machineStates, err := s.etcdRegistry.Machines()
+	if err != nil {
+		return nil, err
+	}
 	s.hasNonGRPCAgents = false
 	for _, state := range machineStates {
 		if !state.Capabilities.Has("GRPC") {
@@ -162,7 +165,10 @@ func (s *rpcserver) GetUnits(ctx context.Context, filter *pb.UnitFilter) (*pb.Un
 
 	if s.hasNonGRPCAgents {
 		log.Debug("Merging etcd with inmemory units in GetUnits()")
-		etcdUnits, _ := s.etcdRegistry.Units()
+		etcdUnits, err := s.etcdRegistry.Units()
+		if err != nil {
+			return nil, err
+		}
 
 		unitNames := make(map[string]struct{}, len(units))
 		for _, unit := range units {
@@ -187,7 +193,10 @@ func (s *rpcserver) GetUnitStates(ctx context.Context, filter *pb.UnitStateFilte
 
 	if s.hasNonGRPCAgents {
 		log.Debug("Merging etcd with inmemory unit states in GetUnitStates()")
-		etcdUnitStates, _ := s.etcdRegistry.UnitStates()
+		etcdUnitStates, err := s.etcdRegistry.UnitStates()
+		if err != nil {
+			return nil, err
+		}
 
 		unitStateNames := make(map[string]string, len(states))
 		for _, state := range states {

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coreos/fleet/Godeps/_workspace/src/google.golang.org/grpc/codes"
 	"github.com/coreos/fleet/debug"
 	"github.com/coreos/fleet/log"
+	"github.com/coreos/fleet/machine"
 	pb "github.com/coreos/fleet/protobuf"
 	"github.com/coreos/fleet/registry"
 )
@@ -78,8 +79,8 @@ func NewRPCServer(reg registry.Registry, addr string) (*rpcserver, error) {
 	}
 	s.hasNonGRPCAgents = false
 	for _, state := range machineStates {
-		if !state.Capabilities.Has("GRPC") {
-			log.Info("Enabled unit state storage into etcd!")
+		if !state.Capabilities.Has(machine.CapGRPC) {
+			log.Info("Fleet cluster has non gRPC agents!. Enabled unit state storage into etcd!")
 			s.hasNonGRPCAgents = true
 			break
 		}
@@ -124,9 +125,6 @@ func (s *rpcserver) GetScheduledUnits(ctx context.Context, unitFilter *pb.UnitFi
 	}
 
 	units, err := s.localRegistry.Schedule()
-	if err != nil {
-		return nil, err
-	}
 
 	return &pb.ScheduledUnits{Units: units}, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -129,8 +129,8 @@ func New(cfg config.Config) (*Server, error) {
 	} else {
 		regMux := genericReg.(*rpc.RegistryMux)
 		e = engine.New(reg, lManager, rStream, mach, regMux.EngineChanged)
-		if cfg.DisableEngine && e.IsGrpcLeader() {
-			regMux.ConnectRPCRegistry()
+		if cfg.DisableEngine {
+			go regMux.ConnectToRegistry(e)
 		}
 	}
 


### PR DESCRIPTION
This PR aims to merge the unit state from etcd and `inmemory` grpc when both versions have to co-live in the cluster. This could help the whole migration process as there isn't any cluster split.
- Support to pivot from a fleet etcd leader to a grpc leader and viceversa. 

FYI: @teemow 

ping @htr 
