### PR TITLE
Fix error when etcd has no leader

### DIFF
--- a/engine/rpcengine.go
+++ b/engine/rpcengine.go
@@ -15,6 +15,7 @@
 package engine
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -24,27 +25,32 @@ import (
 	"github.com/coreos/fleet/registry"
 )
 
-// IsGrpcLeader checks if the current leader has gRPC capabilities enabled
-func (e *Engine) IsGrpcLeader() bool {
+// IsGrpcLeader checks if the current leader has gRPC capabilities enabled or error
+// if there is not a elected leader yet.
+func (e *Engine) IsGrpcLeader() (bool, error) {
 	leader, err := e.lManager.GetLease(engineLeaseName)
 	if err != nil {
 		log.Errorf("Unable to determine current lease: %v", err)
-		return false
+		return false, err
+	}
+	// It can happen that the leader is not yet stored in etcd and nor error (line 122 pkg/lease/etcd.go)
+	if leader == nil {
+		return false, errors.New("Unable to get the current leader")
 	}
 
 	leaderState, err := e.getMachineState(leader.MachineID())
 	if err != nil {
 		log.Errorf("Unable to determine current lease: %v", err)
-		return false
+		return false, err
 	}
 
 	if leaderState.Capabilities != nil && leaderState.Capabilities.Has(machine.CapGRPC) {
-		return true
+		return true, nil
 	}
 
 	log.Info("Engine leader has no gRPC capabilities enabled!")
 
-	return false
+	return false, nil
 }
 
 func (e *Engine) rpcLeadership(leaseTTL time.Duration, machID string) lease.Lease {


### PR DESCRIPTION
This fix an issue reported by @denderello when scheduling the fleet replicator. It motivated to restart the fleet agent ending up in a fleet splited cluster due to two reasons:
- 18. has a wrong fleetd binary
- Some exceptions were found during the debugging on which we could see how the fleetd raises an exception due to the lack of fleet leader stored in etcd.

```
panic: runtime error: invalid memory address or nil pointer dereference
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: [signal 0xb code=0x1 addr=0x28 pc=0x59f600]
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: goroutine 85 [running]:
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: github.com/coreos/fleet/engine.(*Engine).IsGrpcLeader(0xc208128400, 0x7f7912a380e8)
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: /home/vagrant/giantswarm_repo/fleet/gopath/src/github.com/coreos/fleet/engine/rpcengine.go:35 +0x180
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: github.com/coreos/fleet/registry/rpc.(*RegistryMux).ConnectToRegistry(0xc2080801b0, 0xc208128400)
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: /home/vagrant/giantswarm_repo/fleet/gopath/src/github.com/coreos/fleet/registry/rpc/registrymux.go:53 +0x28
Mar 30 10:21:46 0a039bd74d51b324 fleetd.grpc[11415]: created by github.com/coreos/fleet/server.New
```

ping @htr @denderello 
