### PR TITLE
Stop rpc server whenever current engine is not leader anymore

### DIFF
--- a/registry/rpc/registrymux.go
+++ b/registry/rpc/registrymux.go
@@ -158,10 +158,14 @@ func (r *RegistryMux) EngineChanged(newEngine machine.MachineState) {
 	r.handlingEngineChange.Lock()
 	defer r.handlingEngineChange.Unlock()
 
+	stopServer := false
+	if r.currentEngine.ID != newEngine.ID {
+		stopServer = true
+	}
 	r.currentEngine = newEngine
 	log.Infof("Engine changed, checking capabilities %+v", newEngine)
 	if r.localMachine.State().Capabilities.Has(machine.CapGRPC) {
-		if r.rpcserver != nil && r.rpcRegistry != nil && !r.rpcRegistry.IsRegistryReady() {
+		if r.rpcserver != nil && ((r.rpcRegistry != nil && !r.rpcRegistry.IsRegistryReady()) || stopServer) {
 			// If the engine changed, we need to stop the rpc server
 			r.rpcserver.Stop()
 			r.rpcserver = nil


### PR DESCRIPTION
In relation with https://github.com/giantswarm/fleet/pull/27

We found a race condition that we have to fix. 

Race condition: Machine 103 is leader, however it is restarted and the leadership is stolen by other. However the rpc server never stops cause the following condition is not satisfied `r.rpcRegistry != nil && !r.rpcRegistry.IsRegistryReady` in line `161` in `registrymux.go` EngineChanged. That causes the rpcRegistry to use the current one, which is himself. This causes a fleet cluster split situation on which other agents point to the new leader while 103 is still thinking that it is the leader cause the rpc connection was READY. In conclusion, the rpc server had to be stopped to avoid this issue

I use this boolean condition to avoid querying etcd to get the leader.

ping @htr 
