### PR TITLE
Non scheduled units REQUIRE inactive state by default

### DIFF
--- a/registry/rpc/inmemory.go
+++ b/registry/rpc/inmemory.go
@@ -85,7 +85,7 @@ func (r *inmemoryRegistry) Schedule() (units []pb.ScheduledUnit, err error) {
 	return units, nil
 }
 
-func (r *inmemoryRegistry) ScheduledUnit(unitName string) (unit *pb.ScheduledUnit, exists bool) {
+func (r *inmemoryRegistry) ScheduledUnit(unitName string) (unit *pb.ScheduledUnit) {
 	if DebugInmemoryRegistry {
 		defer debug.Exit_(debug.Enter_(unitName))
 	}
@@ -95,9 +95,14 @@ func (r *inmemoryRegistry) ScheduledUnit(unitName string) (unit *pb.ScheduledUni
 	if schedUnit, exists := r.scheduledUnits[unitName]; exists {
 		su := &schedUnit
 		su.CurrentState = r.getScheduledUnitState(unitName, schedUnit.MachineID)
-		return su, true
+		return su
 	}
-	return nil, false
+
+	return &pb.ScheduledUnit{
+		Name:         unitName,
+		MachineID:    "",
+		CurrentState: pb.TargetState_INACTIVE,
+	}
 }
 
 func (r *inmemoryRegistry) Unit(name string) (pb.Unit, bool) {

--- a/registry/rpc/rpcserver.go
+++ b/registry/rpc/rpcserver.go
@@ -134,11 +134,9 @@ func (s *rpcserver) GetScheduledUnit(ctx context.Context, name *pb.UnitName) (*p
 		defer debug.Exit_(debug.Enter_(name.Name))
 	}
 
-	su, exists := s.localRegistry.ScheduledUnit(name.Name)
-	if exists {
-		return &pb.MaybeScheduledUnit{IsScheduled: &pb.MaybeScheduledUnit_Unit{Unit: su}}, nil
-	}
-	return &pb.MaybeScheduledUnit{IsScheduled: &pb.MaybeScheduledUnit_Notfound{Notfound: &pb.NotFound{}}}, nil
+	su := s.localRegistry.ScheduledUnit(name.Name)
+
+	return &pb.MaybeScheduledUnit{IsScheduled: &pb.MaybeScheduledUnit_Unit{Unit: su}}, nil
 }
 
 func (s *rpcserver) GetUnit(ctx context.Context, name *pb.UnitName) (*pb.MaybeUnit, error) {


### PR DESCRIPTION
Short long story:
- Old version sets state inactive for the no scheduled units. This is done in `registry/job_state.go` in the function `determineJobState`. Its TargetMachineID is the empty string but its state is inactive.Therefore we have to do the same for backwards compatibility.
- In the `client/registry.go` there is a conversion from the job.ScheduledUnit to get its CurrentState. In our previous version, the ScheduledUnit was nil so... no CurrentState. This should have been `inactive` even if its machine ID was `""`

ping @htr 
