### PR TITLE
Avoid constant leader re-elections under heavy load

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	DisableWatches          bool
 	VerifyUnits             bool
 	AuthorizedKeysFile      string
+	UseLeaseTTL             bool
 }
 
 func (c *Config) Capabilities() machine.Capabilities {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,13 +68,6 @@ func New(reg CompleteRegistry, lManager lease.Manager, rStream pkg.EventStream, 
 
 func (e *Engine) Run(ival time.Duration, stop <-chan struct{}) {
 	leaseTTL := ival * 5
-	if e.machine.State().Capabilities.Has(machine.CapGRPC) {
-		// With grpc it doesn't make sense to set to 5secs the TTL of the etcd key.
-		// This has a special impact whenever we have high worload in the cluster, cause
-		// it'd provoke constant leader re-elections.
-		// TODO: IMHO, this should be configurable via a flag to disable the TTL.
-		leaseTTL = ival * 1000000
-	}
 	machID := e.machine.State().ID
 
 	reconcile := func() {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,6 +68,13 @@ func New(reg CompleteRegistry, lManager lease.Manager, rStream pkg.EventStream, 
 
 func (e *Engine) Run(ival time.Duration, stop <-chan struct{}) {
 	leaseTTL := ival * 5
+	if e.machine.State().Capabilities.Has(machine.CapGRPC) {
+		// With grpc it doesn't make sense to set to 5secs the TTL of the etcd key.
+		// This has a special impact whenever we have high worload in the cluster, cause
+		// it'd provoke constant leader re-elections.
+		// TODO: IMHO, this should be configurable via a flag to disable the TTL.
+		leaseTTL = ival * 1000000
+	}
 	machID := e.machine.State().ID
 
 	reconcile := func() {

--- a/fleetd/fleetd.go
+++ b/fleetd/fleetd.go
@@ -82,7 +82,7 @@ func main() {
 	cfgset.String("etcd_cafile", "", "SSL Certificate Authority file used to secure etcd communication")
 	cfgset.String("etcd_key_prefix", registry.DefaultKeyPrefix, "Keyspace for fleet data in etcd")
 	cfgset.Float64("etcd_request_timeout", 1.0, "Amount of time in seconds to allow a single etcd request before considering it failed.")
-	cfgset.Float64("engine_reconcile_interval", 2.0, "Interval at which the engine should reconcile the cluster schedule in etcd.")
+	cfgset.Float64("engine_reconcile_interval", 5.0, "Interval at which the engine should reconcile the cluster schedule in etcd.")
 	cfgset.String("public_ip", "", "IP address that fleet machine should publish")
 	cfgset.String("metadata", "", "List of key-value metadata to assign to the fleet machine")
 	cfgset.String("agent_ttl", agent.DefaultTTL, "TTL in seconds of fleet machine state in etcd")
@@ -92,6 +92,7 @@ func main() {
 	cfgset.Bool("disable_watches", false, "Disable the use of etcd watches. Increases scheduling latency")
 	cfgset.Bool("verify_units", false, "DEPRECATED - This option is ignored")
 	cfgset.String("authorized_keys_file", "", "DEPRECATED - This option is ignored")
+	cfgset.Bool("use_lease_ttl", false, "Enable the usage of TTL option when creating a lease key in etcd")
 
 	globalconf.Register("", cfgset)
 	cfg, err := getConfig(cfgset, *cfgPath)
@@ -220,6 +221,7 @@ func getConfig(flagset *flag.FlagSet, userCfgFile string) (*config.Config, error
 		VerifyUnits:             (*flagset.Lookup("verify_units")).Value.(flag.Getter).Get().(bool),
 		TokenLimit:              (*flagset.Lookup("token_limit")).Value.(flag.Getter).Get().(int),
 		AuthorizedKeysFile:      (*flagset.Lookup("authorized_keys_file")).Value.(flag.Getter).Get().(string),
+		UseLeaseTTL:             (*flagset.Lookup("use_lease_ttl")).Value.(flag.Getter).Get().(bool),
 	}
 
 	if cfg.VerifyUnits {

--- a/server/server.go
+++ b/server/server.go
@@ -104,7 +104,7 @@ func New(cfg config.Config) (*Server, error) {
 		reg        engine.CompleteRegistry
 		genericReg interface{}
 	)
-	lManager := lease.NewEtcdLeaseManager(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)
+	lManager := lease.NewEtcdLeaseManager(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout, cfg.UseLeaseTTL)
 
 	if !cfg.EnableGRPC {
 		genericReg = registry.NewEtcdRegistry(kAPI, cfg.EtcdKeyPrefix, etcdRequestTimeout)


### PR DESCRIPTION
To avoid constant leader re-elections under heavy workload it's convenient to disable the TTL of the lease leader. This is a temporal patch that will set a high value to the TTL ONLY when using `gRPC`.

As a long term solution, we should add a flag to enable/disable the usage of TTL for the keys of the leases.

ping @teemow 
